### PR TITLE
Upgrade ODAHU SDK dependency to 1.4.0-rc3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         ]
     },
     install_requires=[
-        'odahu-flow-sdk==1.4.0rc1',
+        'odahu-flow-sdk==1.4.0rc3',
         'requests>=2.22.0'
     ],
     extras_require={


### PR DESCRIPTION
In https://github.com/odahu/odahu-flow/pull/477 `predictor` field was introduced. This PR upgrades a client library to support this required field.
